### PR TITLE
Optimize and update obsoletes inside VehicleUtil

### DIFF
--- a/src/Commands/CommandOpenStorage.cs
+++ b/src/Commands/CommandOpenStorage.cs
@@ -47,7 +47,7 @@ namespace Essentials.Commands
             var player = src.ToPlayer();
             var look = player.Look;
 
-            if (PhysicsUtility.raycast(new Ray(look.aim.position, look.aim.forward), out RaycastHit hit, Mathf.Infinity, RayMasks.BARRICADE))
+            if (Physics.Raycast(look.aim.position, look.aim.forward, out RaycastHit hit, Mathf.Infinity, RayMasks.BARRICADE))
             {
                 InteractableStorage storage = hit.transform.GetComponent<InteractableStorage>();
 

--- a/src/Commands/CommandRefuelVehicle.cs
+++ b/src/Commands/CommandRefuelVehicle.cs
@@ -72,8 +72,8 @@ namespace Essentials.Commands {
         }
 
         private void RefuelVehicle(InteractableVehicle veh) {
-            VehicleManager.instance.channel.send("tellVehicleFuel", ESteamCall.ALL,
-                ESteamPacket.UPDATE_UNRELIABLE_BUFFER, veh.instanceID, veh.asset.fuel);
+            veh.tellFuel(veh.asset.fuel); // Actually refuels
+            VehicleManager.sendVehicleFuel(veh, veh.asset.fuel); // Sends update to player inside
         }
 
     }

--- a/src/Commands/MiscCommands.cs
+++ b/src/Commands/MiscCommands.cs
@@ -772,7 +772,7 @@ namespace Essentials.Commands {
                         return CommandResult.LangError("BLACKLISTED_VEHICLE", $"{optAsset.FriendlyName} ({optAsset.id})");
                     }
 
-                    VehicleTool.giveVehicle(src.ToPlayer().UnturnedPlayer, optAsset.id);
+                    VehicleTool.SpawnVehicleForPlayer(src.ToPlayer().UnturnedPlayer, optAsset);
 
                     EssLang.Send(src, "RECEIVED_VEHICLE", optAsset.FriendlyName, optAsset.id);
                     break;

--- a/src/Commands/MiscCommands.cs
+++ b/src/Commands/MiscCommands.cs
@@ -36,7 +36,6 @@ using SDG.Unturned;
 using UnityEngine;
 using Essentials.Common.Util;
 using Essentials.Components.Player;
-using System.Reflection;
 
 namespace Essentials.Commands {
 
@@ -791,7 +790,7 @@ namespace Essentials.Commands {
 
                     if (args[0].Equals("*")) {
                         UServer.Players.ForEach(p => {
-                            VehicleTool.giveVehicle(p.UnturnedPlayer, optAsset.id);
+                            VehicleTool.SpawnVehicleForPlayer(p.UnturnedPlayer, optAsset);
                         });
 
                         EssLang.Send(src, "GIVEN_VEHICLE_ALL", optAsset.FriendlyName, optAsset.id);
@@ -799,7 +798,7 @@ namespace Essentials.Commands {
                         return CommandResult.LangError("PLAYER_NOT_FOUND", args[0]);
                     } else {
                         var target = args[0].ToPlayer;
-                        VehicleTool.giveVehicle(target.UnturnedPlayer, optAsset.id);
+                        VehicleTool.SpawnVehicleForPlayer(target.UnturnedPlayer, optAsset);
 
                         EssLang.Send(src, "GIVEN_VEHICLE", optAsset.FriendlyName, optAsset.id, target.DisplayName);
                     }

--- a/src/Common/Util/VehicleUtil.cs
+++ b/src/Common/Util/VehicleUtil.cs
@@ -26,7 +26,6 @@ using System.Globalization;
 using System.Linq;
 using Essentials.Api.Module;
 using static Essentials.Api.UEssentials;
-using SDG.Unturned;
 using Essentials.Api.Command;
 using Essentials.Api;
 using Essentials.I18n;
@@ -34,7 +33,7 @@ using Essentials.I18n;
 namespace Essentials.Common.Util {
 
     public static class VehicleUtil {
-
+        private static readonly System.Collections.Generic.List<VehicleAsset> assets = new System.Collections.Generic.List<VehicleAsset>(); // avoid re-allocation per usage
         public static Asset GetVehicle(string name)
         {
             if (ushort.TryParse(name, out var id))
@@ -43,22 +42,23 @@ namespace Essentials.Common.Util {
             }
             else
             {
-                ushort? idToString = 0;
+                // Updated obsolete list-fetch:
+                if(assets.Count == 0) // only populate list once
+                    Assets.find(assets); // assets normally do not update at runtime, except during server start (i.e. after downloading workshop)
 
-                Asset[] assets = Assets.find(EAssetType.VEHICLE);
-                foreach (Asset ia in assets)
+                for (int i = 0; i < assets.Count; i++) // faster than foreach (especially until dotnet 10)
                 {
-                    if (ia != null && ia.FriendlyName != null && ia.FriendlyName.ToLower().Contains(name.ToString()))
-                    {
-                        idToString = ia.id;
-                        break;
-                    }
+                    var ia = assets[i];
+                    if (ia?.FriendlyName == null)
+                        continue;
+
+                    if (ia.FriendlyName.IndexOf(name, System.StringComparison.OrdinalIgnoreCase) >= 0) // avoid .ToLower() which allocates each iteration
+                        return ia; // found the VehicleAsset here
                 }
 
-                return Assets.find(EAssetType.VEHICLE, idToString.Value);
+                return null;
             }
         }
-
     }
 
 }

--- a/uEssentials.csproj
+++ b/uEssentials.csproj
@@ -62,7 +62,7 @@
     <PackageReference Include="RocketModFix.Rocket.Core" Version="4.23.1" />
     <PackageReference Include="RocketModFix.Rocket.Unturned" Version="4.23.1" />
     <PackageReference Include="RocketModFix.UnityEngine.Redist" Version="2022.3.62.3" />
-    <PackageReference Include="RocketModFix.Unturned.Redist" Version="3.24.2" />
+    <PackageReference Include="RocketModFix.Unturned.Redist.Client" Version="3.26.2.2" />
   </ItemGroup>
   <ItemGroup>
     <Compile Remove="Properties\AssemblyInfo - copia.cs" />


### PR DESCRIPTION
- `Assets.find(EAssetType.VEHICLE);` (obsolete) -> Assets.find(list)
- Comparer optimization in for-loop (avoid .ToLower()-allocations)
- Avoid re-fetch from `Assets.find(VEHICLE, id)`, we already got the asset reference ourselves